### PR TITLE
restoring the B/W debug canvas

### DIFF
--- a/Examples/simple_image.html
+++ b/Examples/simple_image.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-  
+
 
 <img id="v1" src="./Data/armchair.jpg"></img>
     <script type='text/javascript'>
@@ -26,17 +26,20 @@ var trackable = {
 }
 
 window.addEventListener('artoolkitX-loaded', () => {
-  
+
 ar1.addEventListener('getMarker', (trackableInfo) => {
     console.log("TrackableID: " + trackableInfo.data.trackableId);
     console.log(trackableInfo.data.transformation);
 });
 
 try {
-    ar1.setLogLevel(0);    
+    // we set the Log level and so also a debug canvas
+    ar1.setLogLevel(0);
+    // we st a different Threshold
+    ar1.setThreshold(200);
     ar1.start().then( () => {
         console.log("start done");
-        var trackableId = ar1.addTrackable(trackable);    
+        var trackableId = ar1.addTrackable(trackable);
         interval = setInterval(function() {
           ar1.process(v1);
         }, 13);

--- a/Source/artoolkitX.api.js
+++ b/Source/artoolkitX.api.js
@@ -519,7 +519,7 @@ import artoolkitXjs from "./artoolkitx.js";
     ARController.prototype.setThreshold = function (threshold) {
         this.threshold = threshold;
         artoolkitXjs.setTrackerOptionInt(
-            artoolkitXjs.TrackableOptions.ARW_TRACKER_OPTION_SQUARE_THRESHOLD,
+            artoolkitXjs.TrackableOptions.ARW_TRACKER_OPTION_SQUARE_THRESHOLD.value,
             threshold
         );
     };

--- a/Source/artoolkitX.api.js
+++ b/Source/artoolkitX.api.js
@@ -726,9 +726,17 @@ import artoolkitXjs from "./artoolkitx.js";
           See setDebugMode.
       */
      ARController.prototype.debugDraw = function () {
-         // var debugBuffer = new Uint8ClampedArray(Module.HEAPU8.buffer, this._bwpointer, this.framesize);
-         // var id = new ImageData(debugBuffer, this.videoWidth, this.videoHeight);
-         // this.ctx.putImageData(id, 0, 0);
+        var videoMalloc = artoolkitXjs.videoMalloc;
+        var debugBuffer = new Uint8ClampedArray(artoolkitXjs.HEAPU8.buffer, videoMalloc.lumaFramePointer, videoMalloc.framesize);
+        var id = new ImageData(new Uint8ClampedArray(this.canvas.width*this.canvas.height*4), this.canvas.width, this.canvas.height);
+    		for (var i=0, j=0; i<debugBuffer.length; i++, j+=4) {
+    			var v = debugBuffer[i];
+    			id.data[j+0] = v;
+    			id.data[j+1] = v;
+    			id.data[j+2] = v;
+    			id.data[j+3] = 255;
+    		}
+        this.ctx.putImageData(id, 0, 0);
 
         //Debug Luma
         var lumaBuffer = new Uint8ClampedArray(this.framesize);

--- a/Source/artoolkitX.api.js
+++ b/Source/artoolkitX.api.js
@@ -58,6 +58,7 @@ import artoolkitXjs from "./artoolkitx.js";
         this._lumaCtx = undefined;
         this.cameraParaFileURL = cameraPara;
         this.debug = false;
+        this.threshold = 100;
     };
 
     ARController.prototype.start = async function () {
@@ -516,6 +517,7 @@ import artoolkitXjs from "./artoolkitx.js";
           @param {number}     threshold An integer in the range [0,255] (inclusive).
       */
     ARController.prototype.setThreshold = function (threshold) {
+        this.threshold = threshold;
         artoolkitXjs.setTrackerOptionInt(
             artoolkitXjs.TrackableOptions.ARW_TRACKER_OPTION_SQUARE_THRESHOLD,
             threshold
@@ -731,7 +733,12 @@ import artoolkitXjs from "./artoolkitx.js";
         var id = new ImageData(new Uint8ClampedArray(this.canvas.width*this.canvas.height*4), this.canvas.width, this.canvas.height);
     		for (var i=0, j=0; i<debugBuffer.length; i++, j+=4) {
     			var v = debugBuffer[i];
-    			id.data[j+0] = v;
+          if (v > this.threshold) {
+            v = 255;
+          } else {
+            v = 0;
+          }
+          id.data[j+0] = v;
     			id.data[j+1] = v;
     			id.data[j+2] = v;
     			id.data[j+3] = 255;


### PR DESCRIPTION
As described in the issue https://github.com/augmentmy-world/artoolkitX.js/issues/4 with the debugDraw() the canvas is not a Black and White canvas but filled with the frames from the video/image stream.
As in the jsartoolkit5 the debug canvas should be refilled. 
This will not affect performaces because enabled only for debugging pourposes.